### PR TITLE
Don't try to divide by zero if CPU scaling frequency min and max are equal

### DIFF
--- a/src/powerkit_cpu.cpp
+++ b/src/powerkit_cpu.cpp
@@ -428,10 +428,10 @@ const QPair<int, QString> Cpu::getCpuFreqLabel()
     int freqMin = Cpu::getMinFrequency();
     int freqMax = Cpu::getMaxFrequency();
     int progress;
-    if (freqMax > freqMin) {
-        progress = ((currentCpuFreq - freqMin) * 100) / (freqMax - freqMin);
-    } else {
+    if (freqMax == freqMin) {
         progress = 100;
+    } else {
+        progress = ((currentCpuFreq - freqMin) * 100) / (freqMax - freqMin);
     }
 
     result.first = progress;

--- a/src/powerkit_cpu.cpp
+++ b/src/powerkit_cpu.cpp
@@ -427,7 +427,12 @@ const QPair<int, QString> Cpu::getCpuFreqLabel()
 
     int freqMin = Cpu::getMinFrequency();
     int freqMax = Cpu::getMaxFrequency();
-    int progress = ((currentCpuFreq - freqMin) * 100) / (freqMax - freqMin);
+    int progress;
+    if (freqMax > freqMin) {
+        progress = ((currentCpuFreq - freqMin) * 100) / (freqMax - freqMin);
+    } else {
+        progress = 100;
+    }
 
     result.first = progress;
     result.second = QString("%1\nGhz").arg(QString::number(currentFancyFreq / 1000000, 'f', 2));


### PR DESCRIPTION
I just built and installed powerkit for the first time. When I tried to open the config GUI, it crashed with a floating point exception. I tracked down the issue to line 430 in `powerkit_cpu.cpp`, which calculates the current CPU frequency as a percentage within the configured scaling range. My min and max values are equal, so this leads to a division by zero. This PR handles this corner case (I interpreted it as 100% progress).