### PR TITLE
Separate blank and lock

### DIFF
--- a/src/powerkit_common.h
+++ b/src/powerkit_common.h
@@ -70,5 +70,6 @@ namespace PowerKit
 #define POWERKIT_DBUS_PROPERTIES "org.freedesktop.DBus.Properties"
 #define POWERKIT_SCREENSAVER_LOCK_CMD "xsecurelock"
 #define POWERKIT_SCREENSAVER_TIMEOUT_BLANK 300
+#define POWERKIT_SCREENSAVER_TIMEOUT_LOCK 600
 
 #endif // POWERKIT_COMMON_H

--- a/src/powerkit_dialog.cpp
+++ b/src/powerkit_dialog.cpp
@@ -53,6 +53,7 @@ Dialog::Dialog(QWidget *parent,
     , cpuFreqLabel(nullptr)
     , cpuTempLabel(nullptr)
     , screensaverBlank(nullptr)
+    , screensaverLock(nullptr)
     , hasCpuCoreTemp(false)
     , hasBattery(false)
 {
@@ -437,7 +438,7 @@ void Dialog::setupWidgets()
     const auto ssContainerLayout = new QHBoxLayout(ssContainer);
     ssContainerLayout->setMargin(0);
 
-    const auto screensaverBlankLabel = new QLabel(tr("Screen Saver Timeout"), this);
+    const auto screensaverBlankLabel = new QLabel(tr("Blank screen"), this);
     screensaverBlank = new QSpinBox(this);
     screensaverBlank->setMaximumWidth(MAX_WIDTH);
     screensaverBlank->setMinimumWidth(MAX_WIDTH);
@@ -448,6 +449,18 @@ void Dialog::setupWidgets()
 
     ssContainerLayout->addWidget(screensaverBlankLabel);
     ssContainerLayout->addWidget(screensaverBlank);
+
+    const auto screensaverLockLabel = new QLabel(tr("Lock screen"), this);
+    screensaverLock = new QSpinBox(this);
+    screensaverLock->setMaximumWidth(MAX_WIDTH);
+    screensaverLock->setMinimumWidth(MAX_WIDTH);
+    screensaverLock->setMinimum(1);
+    screensaverLock->setMaximum(1000);
+    screensaverLock->setSuffix(QString(" %1").arg(tr("min")));
+    screensaverLock->setPrefix(tr("After "));
+
+    ssContainerLayout->addWidget(screensaverLockLabel);
+    ssContainerLayout->addWidget(screensaverLock);
 
     // notify
     const auto notifyContainer = new QGroupBox(this);
@@ -615,6 +628,8 @@ void Dialog::connectWidgets()
             this, SLOT(handleBacklightMouseWheel(bool)));
     connect(screensaverBlank, SIGNAL(valueChanged(int)),
             this, SLOT(handleScreensaverBlank(int)));
+    connect(screensaverLock, SIGNAL(valueChanged(int)),
+            this, SLOT(handleScreensaverLock(int)));
 }
 
 // load settings and set defaults
@@ -774,6 +789,9 @@ void Dialog::loadSettings()
 
     screensaverBlank->setValue(Settings::getValue(CONF_SCREENSAVER_TIMEOUT_BLANK,
                                                   POWERKIT_SCREENSAVER_TIMEOUT_BLANK).toInt() / 60);
+
+    screensaverLock->setValue(Settings::getValue(CONF_SCREENSAVER_TIMEOUT_LOCK,
+                                                  POWERKIT_SCREENSAVER_TIMEOUT_LOCK).toInt() / 60);
 }
 
 void Dialog::saveSettings()
@@ -1150,4 +1168,9 @@ void Dialog::handleBacklightMouseWheel(bool triggered)
 void Dialog::handleScreensaverBlank(int value)
 {
     Settings::setValue(CONF_SCREENSAVER_TIMEOUT_BLANK, value * 60);
+}
+
+void Dialog::handleScreensaverLock(int value)
+{
+    Settings::setValue(CONF_SCREENSAVER_TIMEOUT_LOCK, value * 60);
 }

--- a/src/powerkit_dialog.h
+++ b/src/powerkit_dialog.h
@@ -78,6 +78,7 @@ namespace PowerKit
         QLabel *cpuTempLabel;
 
         QSpinBox *screensaverBlank;
+        QSpinBox *screensaverLock;
 
         bool hasCpuCoreTemp;
         bool hasBattery;
@@ -127,6 +128,7 @@ namespace PowerKit
         void enableLid(bool enabled);
         void handleBacklightMouseWheel(bool triggered);
         void handleScreensaverBlank(int value);
+        void handleScreensaverLock(int value);
     };
 }
 

--- a/src/powerkit_screensaver.cpp
+++ b/src/powerkit_screensaver.cpp
@@ -105,6 +105,8 @@ void ScreenSaver::Update()
 {
     xlock = Settings::getValue(CONF_SCREENSAVER_LOCK_CMD,
                                POWERKIT_SCREENSAVER_LOCK_CMD).toString();
+    blank_time = Settings::getValue(CONF_SCREENSAVER_TIMEOUT_BLANK,
+                               POWERKIT_SCREENSAVER_TIMEOUT_BLANK).toInt();
     lock_time = Settings::getValue(CONF_SCREENSAVER_TIMEOUT_LOCK,
                                POWERKIT_SCREENSAVER_TIMEOUT_LOCK).toInt();
     int exe1 = QProcess::execute("xset",

--- a/src/powerkit_screensaver.cpp
+++ b/src/powerkit_screensaver.cpp
@@ -96,11 +96,11 @@ void ScreenSaver::timeOut()
     qDebug() << "screen idle" << idle_time;
     qDebug() << "screen blank timeout" << blank_time;
     qDebug() << "screen lock timeout" << lock_time;
-    if (idle_time >= lock_time) {
-        Lock();
-    }
     if (idle_time >= blank_time) {
         setDisplaysOff(true);
+    }
+    if (idle_time >= lock_time) {
+        Lock();
     }
 }
 

--- a/src/powerkit_screensaver.cpp
+++ b/src/powerkit_screensaver.cpp
@@ -93,7 +93,9 @@ void ScreenSaver::timeOut()
         return;
     }
     int idle_time = GetSessionIdleTime();
-    qDebug() << "screensaver idle" << idle_time << blank_time << lock_time;
+    qDebug() << "screen idle" << idle_time;
+    qDebug() << "screen blank timeout" << blank_time;
+    qDebug() << "screen lock timeout" << lock_time;
     if (idle_time >= lock_time) {
         Lock();
     }

--- a/src/powerkit_screensaver.cpp
+++ b/src/powerkit_screensaver.cpp
@@ -96,7 +96,8 @@ void ScreenSaver::timeOut()
     qDebug() << "screensaver idle" << idle_time << blank_time << lock_time;
     if (idle_time >= lock_time) {
         Lock();
-    } else if (idle_time >= blank_time) {
+    }
+    if (idle_time >= blank_time) {
         setDisplaysOff(true);
     }
 }
@@ -116,6 +117,11 @@ void ScreenSaver::Update()
     int exe3 = QProcess::execute("xset",
                                  QStringList() << "s" << QString::number(lock_time));
     qDebug() << "screensaver update" << exe1 << exe2 << exe3;
+    if (lock_time < blank_time) {
+        int lock_before_blank = QProcess::execute("xset",
+                                 QStringList() << "s" << "noblank");
+        qDebug() << "screensaver update noblank" << lock_before_blank;
+    }
     SimulateUserActivity();
 }
 
@@ -124,7 +130,6 @@ void ScreenSaver::Lock()
     if (xlock.isEmpty()) { return; }
     qDebug() << "screensaver lock";
     QProcess::startDetached(xlock, QStringList());
-    setDisplaysOff(true);
 }
 
 void ScreenSaver::SimulateUserActivity()

--- a/src/powerkit_screensaver.cpp
+++ b/src/powerkit_screensaver.cpp
@@ -47,7 +47,8 @@ using namespace PowerKit;
 
 ScreenSaver::ScreenSaver(QObject *parent)
     : QObject(parent)
-    , blank(POWERKIT_SCREENSAVER_TIMEOUT_BLANK)
+    , blank_time(POWERKIT_SCREENSAVER_TIMEOUT_BLANK)
+    , lock_time(POWERKIT_SCREENSAVER_TIMEOUT_LOCK)
 {
     timer.setInterval(PK_SCREENSAVER_TIMER);
     connect(&timer, SIGNAL(timeout()),
@@ -91,23 +92,27 @@ void ScreenSaver::timeOut()
         SimulateUserActivity();
         return;
     }
-    int idle = GetSessionIdleTime();
-    qDebug() << "screensaver idle" << idle << blank;
-    if (idle >= blank) { Lock(); }
+    int idle_time = GetSessionIdleTime();
+    qDebug() << "screensaver idle" << idle_time << blank_time << lock_time;
+    if (idle_time >= lock_time) {
+        Lock();
+    } else if (idle_time >= blank_time) {
+        setDisplaysOff(true);
+    }
 }
 
 void ScreenSaver::Update()
 {
     xlock = Settings::getValue(CONF_SCREENSAVER_LOCK_CMD,
                                POWERKIT_SCREENSAVER_LOCK_CMD).toString();
-    blank = Settings::getValue(CONF_SCREENSAVER_TIMEOUT_BLANK,
-                               POWERKIT_SCREENSAVER_TIMEOUT_BLANK).toInt();
+    lock_time = Settings::getValue(CONF_SCREENSAVER_TIMEOUT_LOCK,
+                               POWERKIT_SCREENSAVER_TIMEOUT_LOCK).toInt();
     int exe1 = QProcess::execute("xset",
                                  QStringList() << "-dpms");
     int exe2 = QProcess::execute("xset",
                                  QStringList() << "s" << "on");
     int exe3 = QProcess::execute("xset",
-                                 QStringList() << "s" << QString::number(blank));
+                                 QStringList() << "s" << QString::number(lock_time));
     qDebug() << "screensaver update" << exe1 << exe2 << exe3;
     SimulateUserActivity();
 }

--- a/src/powerkit_screensaver.h
+++ b/src/powerkit_screensaver.h
@@ -27,7 +27,8 @@ namespace PowerKit
     private:
         QTimer timer;
         QMap<quint32, QTime> clients;
-        int blank;
+        int blank_time;
+        int lock_time;
         QString xlock;
 
     signals:

--- a/src/powerkit_settings.h
+++ b/src/powerkit_settings.h
@@ -47,6 +47,7 @@
 #define CONF_KERNEL_BYPASS "kernel_cmd_bypass"
 #define CONF_SCREENSAVER_LOCK_CMD "screensaver_lock_cmd"
 #define CONF_SCREENSAVER_TIMEOUT_BLANK "screensaver_blank_timeout"
+#define CONF_SCREENSAVER_TIMEOUT_LOCK "screensaver_lock_timeout"
 
 namespace PowerKit
 {


### PR DESCRIPTION
I wanted to decouple blanking the screen from locking the screen, because I would like to blank to save power if I step away from the computer briefly, but I don't want to lock the screen automatically until much later.

This PR uses the previous "blank" preference for blanking, and adds a new separate preference for locking.

I also made it possible to lock first and blank later, in case someone has the opposite use case. (This requires `noblank` to be set with `xset`, because the default behaviour is to blank). Sometimes I see a crosshatch pattern before the xsecurelock saver kicks in, but this appears to be a random (?) glitch and not something that powerkit is responsible for. Most of the time the saver is displayed immediately, as expected.